### PR TITLE
Add CS

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ Notice this is not a promise, but a list of possible features that could be adde
 - [x] Basic settings
 - [ ] Add Area of Specialization & Free Electives
 - [ ] Review dependencies, courses etc. for accurate information
-- [ ] Add more/different study programs with dependencies(CS)
+- [ ] Add more/different study programs with dependencies
+  - [x] CS 
 - [ ] Better graphs for progress
 - [ ] Better Theming/colors
 - [ ] Links/References to kusss, moodle etc.

--- a/src/components/program-toggle.tsx
+++ b/src/components/program-toggle.tsx
@@ -6,36 +6,36 @@ import {
 } from "@/components/ui/dropdown-menu.tsx";
 import {Button} from "@/components/ui/button.tsx";
 import {useAtom} from "jotai";
-import {Programm, programmAtom} from "@/store/settings.ts";
+import {Program, programAtom} from "@/store/settings.ts";
 import {toast} from "sonner";
 import {planningAtom} from "@/store/planning.ts";
 import {gradesAtom} from "@/store/grades.ts";
 
-export function ProgrammToggle() {
-    const [, setProgramm] = useAtom(programmAtom)
+export function ProgramToggle() {
+    const [, setProgram] = useAtom(programAtom)
 
     const [, setPlanning] = useAtom(planningAtom);
     const [, setGrading] = useAtom(gradesAtom);
 
-    const changeProgramm = (value: Programm) => {
-        setProgramm(value)
+    const changeProgram = (value: Program) => {
+        setProgram(value)
 
         setPlanning([])
         setGrading([])
 
-        toast.success("Successfully change Bachelor's Programm")
+        toast.success("Successfully change Bachelor's Program")
     }
 
     return (
         <DropdownMenu>
             <DropdownMenuTrigger className="w-full" asChild>
                 <Button variant="destructive" className="w-full">
-                    <span>Change Programm (Resets all data)</span>
+                    <span>Change Program (Resets all data)</span>
                 </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent>
-                <DropdownMenuItem onClick={() => (changeProgramm("AI"))}>AI</DropdownMenuItem>
-                <DropdownMenuItem onClick={() => (changeProgramm("CS"))}>CS</DropdownMenuItem>
+                <DropdownMenuItem onClick={() => (changeProgram("AI"))}>AI</DropdownMenuItem>
+                <DropdownMenuItem onClick={() => (changeProgram("CS"))}>CS</DropdownMenuItem>
             </DropdownMenuContent>
         </DropdownMenu>
     )

--- a/src/components/programm-toggle.tsx
+++ b/src/components/programm-toggle.tsx
@@ -28,7 +28,7 @@ export function ProgrammToggle() {
 
     return (
         <DropdownMenu>
-            <DropdownMenuTrigger className="w-full">
+            <DropdownMenuTrigger className="w-full" asChild>
                 <Button variant="destructive" className="w-full">
                     <span>Change Programm (Resets all data)</span>
                 </Button>

--- a/src/components/programm-toggle.tsx
+++ b/src/components/programm-toggle.tsx
@@ -1,0 +1,42 @@
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger
+} from "@/components/ui/dropdown-menu.tsx";
+import {Button} from "@/components/ui/button.tsx";
+import {useAtom} from "jotai";
+import {Programm, programmAtom} from "@/store/settings.ts";
+import {toast} from "sonner";
+import {planningAtom} from "@/store/planning.ts";
+import {gradesAtom} from "@/store/grades.ts";
+
+export function ProgrammToggle() {
+    const [, setProgramm] = useAtom(programmAtom)
+
+    const [, setPlanning] = useAtom(planningAtom);
+    const [, setGrading] = useAtom(gradesAtom);
+
+    const changeProgramm = (value: Programm) => {
+        setProgramm(value)
+
+        setPlanning([])
+        setGrading([])
+
+        toast.success("Successfully change Bachelor's Programm")
+    }
+
+    return (
+        <DropdownMenu>
+            <DropdownMenuTrigger className="w-full">
+                <Button variant="destructive" className="w-full">
+                    <span>Change Programm (Resets all data)</span>
+                </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent>
+                <DropdownMenuItem onClick={() => (changeProgramm("AI"))}>AI</DropdownMenuItem>
+                <DropdownMenuItem onClick={() => (changeProgramm("CS"))}>CS</DropdownMenuItem>
+            </DropdownMenuContent>
+        </DropdownMenu>
+    )
+}

--- a/src/data/ai/courses.ts
+++ b/src/data/ai/courses.ts
@@ -1,0 +1,139 @@
+import {CourseGroup} from "@/types/courses";
+import {generateRawCourses} from "@/data/courses.ts";
+
+export type CourseName =
+	| "Hands-on AI I"
+	| "Introduction to AI"
+	| "Lecture Series Artificial Intelligence"
+	| "Responsible AI"
+	| "Programming in Python I"
+	| "Logic"
+	| "Mathematics for AI I"
+	| "Hands-on AI II"
+	| "Technology and Society"
+	| "Programming in Python II"
+	| "Algorithms and Data Structures I"
+	| "Statistics for AI"
+	| "Mathematics for AI II"
+	| "Artificial Intelligence"
+	| "Algorithms and Data Structures II"
+	| "Machine Learning: Basic Techniques"
+	| "Visualization"
+	| "Machine Learning: Supervised Techniques"
+	| "Mathematics for AI III"
+	| "Seminar in AI"
+	| "Learning from User-generated Data"
+	| "Computational Data Analytics"
+	| "Formal Models"
+	| "Machine Learning: Unsupervised Techniques"
+	| "Machine Learning and Pattern Classification"
+	| "Numerical Optimization"
+	| "Practical Work in AI"
+	| "Introduction to Computational Statistics"
+	| "Natural Language Processing"
+	| "Computational Logics for AI"
+	| "Reinforcement Learning"
+	| "Gender Studies"
+	| "Digital Signal Processing"
+	| "Bachelor Thesis";
+
+export const courseGroups: CourseGroup<CourseName>[] = [
+	{
+		name: "AI Basics and Practical Training",
+		courses: [
+			{ type: "UE", name: "Hands-on AI I", ects: 1.5, available: "WS", recommendedSemester: 1 },
+			{ type: "VL", name: "Hands-on AI I", ects: 1.5, available: "WS", recommendedSemester: 1 },
+			{ type: "UE", name: "Hands-on AI II", ects: 3, available: "SS", recommendedSemester: 2 },
+			{ type: "VL", name: "Hands-on AI II", ects: 1.5, available: "SS", recommendedSemester: 2 },
+			{ type: "VL", name: "Introduction to AI", ects: 3, available: "WS", recommendedSemester: 1 },
+			{ type: "PR", name: "Practical Work in AI", ects: 7.5, available: "WS", recommendedSemester: 5 },
+			{ type: "SE", name: "Seminar in AI", ects: 3, available: "SS", recommendedSemester: 4 },
+			{ type: "UE", name: "Artificial Intelligence", ects: 1.5, available: "WS", recommendedSemester: 3 },
+			{ type: "VL", name: "Artificial Intelligence", ects: 3, available: "WS", recommendedSemester: 3 },
+		],
+	},
+	{
+		name: "AI and Society",
+		courses: [
+			{ type: "VL", name: "Lecture Series Artificial Intelligence", ects: 1.5, available: "WS", recommendedSemester: 1 },
+			{ type: "KV", name: "Responsible AI", ects: 3, available: "WS", recommendedSemester: 1 },
+			{ type: "KV", name: "Technology and Society", ects: 3, available: "SS", recommendedSemester: 2 },
+			{ type: "KV", name: "Gender Studies", ects: 3, available: "SS", recommendedSemester: 6 },
+		],
+	},
+	{
+		name: "Computer Science",
+		courses: [
+			{ type: "UE", name: "Programming in Python I", ects: 3, available: "WS", recommendedSemester: 1 },
+			{ type: "VL", name: "Programming in Python I", ects: 3, available: "WS", recommendedSemester: 1 },
+			{ type: "UE", name: "Programming in Python II", ects: 1.5, available: "SS", recommendedSemester: 2 },
+			{ type: "VL", name: "Programming in Python II", ects: 1.5, available: "SS", recommendedSemester: 2 },
+			{ type: "UE", name: "Algorithms and Data Structures I", ects: 1.5, available: "SS", recommendedSemester: 2 },
+			{ type: "VL", name: "Algorithms and Data Structures I", ects: 3, available: "SS", recommendedSemester: 2 },
+			{ type: "UE", name: "Algorithms and Data Structures II", ects: 1.5, available: "WS", recommendedSemester: 3 },
+			{ type: "VL", name: "Algorithms and Data Structures II", ects: 3, available: "WS", recommendedSemester: 3 },
+		],
+	},
+	{
+		name: "Data Science",
+		courses: [
+			{ type: "UE", name: "Statistics for AI", ects: 3, available: "SS", recommendedSemester: 2 },
+			{ type: "VL", name: "Statistics for AI", ects: 3, available: "SS", recommendedSemester: 2 },
+			{ type: "KV", name: "Machine Learning: Basic Techniques", ects: 3, available: "WS", recommendedSemester: 3 },
+			{ type: "UE", name: "Visualization", ects: 1.5, available: "WS", recommendedSemester: 3 },
+			{ type: "VL", name: "Visualization", ects: 3, available: "WS", recommendedSemester: 3 },
+			{ type: "UE", name: "Learning from User-generated Data", ects: 1.5, available: "SS", recommendedSemester: 4 },
+			{ type: "VL", name: "Learning from User-generated Data", ects: 3, available: "SS", recommendedSemester: 4 },
+			{ type: "KV", name: "Computational Data Analytics", ects: 3, available: "SS", recommendedSemester: 4 },
+			{ type: "UE", name: "Introduction to Computational Statistics", ects: 1.5, available: "WS", recommendedSemester: 5 },
+			{ type: "VL", name: "Introduction to Computational Statistics", ects: 3, available: "WS", recommendedSemester: 5 },
+			{ type: "UE", name: "Natural Language Processing", ects: 1.5, available: "WS", recommendedSemester: 5 },
+			{ type: "VL", name: "Natural Language Processing", ects: 1.5, available: "WS", recommendedSemester: 5 },
+			{ type: "UE", name: "Digital Signal Processing", ects: 1.5, available: "SS", recommendedSemester: 6 },
+			{ type: "VL", name: "Digital Signal Processing", ects: 3, available: "SS", recommendedSemester: 6 },
+		],
+	},
+	{
+		name: "Knowledge Representation and Reasoning",
+		courses: [
+			{ type: "UE", name: "Logic", ects: 1.5, available: "WS", recommendedSemester: 1 },
+			{ type: "VL", name: "Logic", ects: 3, available: "WS", recommendedSemester: 1 },
+			{ type: "UE", name: "Formal Models", ects: 1.5, available: "SS", recommendedSemester: 4 },
+			{ type: "VL", name: "Formal Models", ects: 3, available: "SS", recommendedSemester: 4 },
+			{ type: "UE", name: "Computational Logics for AI", ects: 1.5, available: "WS", recommendedSemester: 5 },
+			{ type: "VL", name: "Computational Logics for AI", ects: 3, available: "WS", recommendedSemester: 5 },
+		],
+	},
+	{
+		name: "Machine Learning and Perception",
+		courses: [
+			{ type: "UE", name: "Machine Learning: Supervised Techniques", ects: 1.5, available: "WS", recommendedSemester: 3 },
+			{ type: "VL", name: "Machine Learning: Supervised Techniques", ects: 3, available: "WS", recommendedSemester: 3 },
+			{ type: "UE", name: "Machine Learning: Unsupervised Techniques", ects: 1.5, available: "SS", recommendedSemester: 4 },
+			{ type: "VL", name: "Machine Learning: Unsupervised Techniques", ects: 3, available: "SS", recommendedSemester: 4 },
+			{ type: "UE", name: "Machine Learning and Pattern Classification", ects: 1.5, available: "SS", recommendedSemester: 4 },
+			{ type: "VL", name: "Machine Learning and Pattern Classification", ects: 3, available: "SS", recommendedSemester: 4 },
+			{ type: "UE", name: "Reinforcement Learning", ects: 1.5, available: "WS", recommendedSemester: 5 },
+			{ type: "VL", name: "Reinforcement Learning", ects: 3, available: "WS", recommendedSemester: 5 },
+		],
+	},
+	{
+		name: "Mathematics",
+		courses: [
+			{ type: "UE", name: "Mathematics for AI I", ects: 3, available: "WS", recommendedSemester: 1 },
+			{ type: "VL", name: "Mathematics for AI I", ects: 6, available: "WS", recommendedSemester: 1 },
+			{ type: "UE", name: "Mathematics for AI II", ects: 3, available: "SS", recommendedSemester: 2 },
+			{ type: "VL", name: "Mathematics for AI II", ects: 6, available: "SS", recommendedSemester: 2 },
+			{ type: "UE", name: "Mathematics for AI III", ects: 3, available: "WS", recommendedSemester: 3 },
+			{ type: "VL", name: "Mathematics for AI III", ects: 6, available: "WS", recommendedSemester: 3 },
+			{ type: "UE", name: "Numerical Optimization", ects: 1.5, available: "SS", recommendedSemester: 4 },
+			{ type: "VL", name: "Numerical Optimization", ects: 3, available: "SS", recommendedSemester: 4 },
+		],
+	},
+	{
+		name: "Bachelor Thesis",
+		courses: [{ type: "SE", name: "Bachelor Thesis", ects: 9, recommendedSemester: 6 }],
+	},
+];
+
+export const rawCourses = generateRawCourses(courseGroups)

--- a/src/data/ai/dependencies.ts
+++ b/src/data/ai/dependencies.ts
@@ -1,46 +1,7 @@
-type DependencyType = "hard" | "soft" | "recommended";
-interface Dependency {
-	name: CourseName;
-	type: DependencyType;
-}
+import {Dependencies} from "@/types/dependencies";
+import {CourseName} from "@/data/ai/courses";
 
-export type CourseName =
-	| "Hands-on AI I"
-	| "Introduction to AI"
-	| "Lecture Series Artificial Intelligence"
-	| "Responsible AI"
-	| "Programming in Python I"
-	| "Logic"
-	| "Mathematics for AI I"
-	| "Hands-on AI II"
-	| "Technology and Society"
-	| "Programming in Python II"
-	| "Algorithms and Data Structures I"
-	| "Statistics for AI"
-	| "Mathematics for AI II"
-	| "Artificial Intelligence"
-	| "Algorithms and Data Structures II"
-	| "Machine Learning: Basic Techniques"
-	| "Visualization"
-	| "Machine Learning: Supervised Techniques"
-	| "Mathematics for AI III"
-	| "Seminar in AI"
-	| "Learning from User-generated Data"
-	| "Computational Data Analytics"
-	| "Formal Models"
-	| "Machine Learning: Unsupervised Techniques"
-	| "Machine Learning and Pattern Classification"
-	| "Numerical Optimization"
-	| "Practical Work in AI"
-	| "Introduction to Computational Statistics"
-	| "Natural Language Processing"
-	| "Computational Logics for AI"
-	| "Reinforcement Learning"
-	| "Gender Studies"
-	| "Digital Signal Processing"
-	| "Bachelor Thesis";
-
-export const dependencies: { name: CourseName; dependencies: Dependency[] }[] = [
+export const dependencies: Dependencies<CourseName> = [
 	{
 		name: "Hands-on AI II",
 		dependencies: [

--- a/src/data/courses.ts
+++ b/src/data/courses.ts
@@ -1,105 +1,14 @@
-import { Course, CourseGroup } from "@/types/courses";
+import {Course, CourseGroup} from "@/types/courses";
 
-export const courseGroups: CourseGroup[] = [
-	{
-		name: "AI Basics and Practical Training",
-		courses: [
-			{ type: "UE", name: "UE Hands-on AI I", ects: 1.5, available: "WS", recommendedSemester: 1 },
-			{ type: "VL", name: "VL Hands-on AI I", ects: 1.5, available: "WS", recommendedSemester: 1 },
-			{ type: "UE", name: "UE Hands-on AI II", ects: 3, available: "SS", recommendedSemester: 2 },
-			{ type: "VL", name: "VL Hands-on AI II", ects: 1.5, available: "SS", recommendedSemester: 2 },
-			{ type: "VL", name: "VL Introduction to AI", ects: 3, available: "WS", recommendedSemester: 1 },
-			{ type: "PR", name: "PR Practical Work in AI", ects: 7.5, available: "WS", recommendedSemester: 5 },
-			{ type: "SE", name: "SE Seminar in AI", ects: 3, available: "SS", recommendedSemester: 4 },
-			{ type: "UE", name: "UE Artificial Intelligence", ects: 1.5, available: "WS", recommendedSemester: 3 },
-			{ type: "VL", name: "VL Artificial Intelligence", ects: 3, available: "WS", recommendedSemester: 3 },
-		],
-	},
-	{
-		name: "AI and Society",
-		courses: [
-			{ type: "VL", name: "VL Lecture Series Artificial Intelligence", ects: 1.5, available: "WS", recommendedSemester: 1 },
-			{ type: "KV", name: "KV Responsible AI", ects: 3, available: "WS", recommendedSemester: 1 },
-			{ type: "KV", name: "KV Technology and Society", ects: 3, available: "SS", recommendedSemester: 2 },
-			{ type: "KV", name: "KV Gender Studies", ects: 3, available: "SS", recommendedSemester: 6 },
-		],
-	},
-	{
-		name: "Computer Science",
-		courses: [
-			{ type: "UE", name: "UE Programming in Python I", ects: 3, available: "WS", recommendedSemester: 1 },
-			{ type: "VL", name: "VL Programming in Python I", ects: 3, available: "WS", recommendedSemester: 1 },
-			{ type: "UE", name: "UE Programming in Python II", ects: 1.5, available: "SS", recommendedSemester: 2 },
-			{ type: "VL", name: "VL Programming in Python II", ects: 1.5, available: "SS", recommendedSemester: 2 },
-			{ type: "UE", name: "UE Algorithms and Data Structures I", ects: 1.5, available: "SS", recommendedSemester: 2 },
-			{ type: "VL", name: "VL Algorithms and Data Structures I", ects: 3, available: "SS", recommendedSemester: 2 },
-			{ type: "UE", name: "UE Algorithms and Data Structures II", ects: 1.5, available: "WS", recommendedSemester: 3 },
-			{ type: "VL", name: "VL Algorithms and Data Structures II", ects: 3, available: "WS", recommendedSemester: 3 },
-		],
-	},
-	{
-		name: "Data Science",
-		courses: [
-			{ type: "UE", name: "UE Statistics for AI", ects: 3, available: "SS", recommendedSemester: 2 },
-			{ type: "VL", name: "VL Statistics for AI", ects: 3, available: "SS", recommendedSemester: 2 },
-			{ type: "KV", name: "KV Machine Learning: Basic Techniques", ects: 3, available: "WS", recommendedSemester: 3 },
-			{ type: "UE", name: "UE Visualization", ects: 1.5, available: "WS", recommendedSemester: 3 },
-			{ type: "VL", name: "VL Visualization", ects: 3, available: "WS", recommendedSemester: 3 },
-			{ type: "UE", name: "UE Learning from User-generated Data", ects: 1.5, available: "SS", recommendedSemester: 4 },
-			{ type: "VL", name: "VL Learning from User-generated Data", ects: 3, available: "SS", recommendedSemester: 4 },
-			{ type: "KV", name: "KV Computational Data Analytics", ects: 3, available: "SS", recommendedSemester: 4 },
-			{ type: "UE", name: "UE Introduction to Computational Statistics", ects: 1.5, available: "WS", recommendedSemester: 5 },
-			{ type: "VL", name: "VL Introduction to Computational Statistics", ects: 3, available: "WS", recommendedSemester: 5 },
-			{ type: "UE", name: "UE Natural Language Processing", ects: 1.5, available: "WS", recommendedSemester: 5 },
-			{ type: "VL", name: "VL Natural Language Processing", ects: 1.5, available: "WS", recommendedSemester: 5 },
-			{ type: "UE", name: "UE Digital Signal Processing", ects: 1.5, available: "SS", recommendedSemester: 6 },
-			{ type: "VL", name: "VL Digital Signal Processing", ects: 3, available: "SS", recommendedSemester: 6 },
-		],
-	},
-	{
-		name: "Knowledge Representation and Reasoning",
-		courses: [
-			{ type: "UE", name: "UE Logic", ects: 1.5, available: "WS", recommendedSemester: 1 },
-			{ type: "VL", name: "VL Logic", ects: 3, available: "WS", recommendedSemester: 1 },
-			{ type: "UE", name: "UE Formal Models", ects: 1.5, available: "SS", recommendedSemester: 4 },
-			{ type: "VL", name: "VL Formal Models", ects: 3, available: "SS", recommendedSemester: 4 },
-			{ type: "UE", name: "UE Computational Logics for AI", ects: 1.5, available: "WS", recommendedSemester: 5 },
-			{ type: "VL", name: "VL Computational Logics for AI", ects: 3, available: "WS", recommendedSemester: 5 },
-		],
-	},
-	{
-		name: "Machine Learning and Perception",
-		courses: [
-			{ type: "UE", name: "UE Machine Learning: Supervised Techniques", ects: 1.5, available: "WS", recommendedSemester: 3 },
-			{ type: "VL", name: "VL Machine Learning: Supervised Techniques", ects: 3, available: "WS", recommendedSemester: 3 },
-			{ type: "UE", name: "UE Machine Learning: Unsupervised Techniques", ects: 1.5, available: "SS", recommendedSemester: 4 },
-			{ type: "VL", name: "VL Machine Learning: Unsupervised Techniques", ects: 3, available: "SS", recommendedSemester: 4 },
-			{ type: "UE", name: "UE Machine Learning and Pattern Classification", ects: 1.5, available: "SS", recommendedSemester: 4 },
-			{ type: "VL", name: "VL Machine Learning and Pattern Classification", ects: 3, available: "SS", recommendedSemester: 4 },
-			{ type: "UE", name: "UE Reinforcement Learning", ects: 1.5, available: "WS", recommendedSemester: 5 },
-			{ type: "VL", name: "VL Reinforcement Learning", ects: 3, available: "WS", recommendedSemester: 5 },
-		],
-	},
-	{
-		name: "Mathematics",
-		courses: [
-			{ type: "UE", name: "UE Mathematics for AI I", ects: 3, available: "WS", recommendedSemester: 1 },
-			{ type: "VL", name: "VL Mathematics for AI I", ects: 6, available: "WS", recommendedSemester: 1 },
-			{ type: "UE", name: "UE Mathematics for AI II", ects: 3, available: "SS", recommendedSemester: 2 },
-			{ type: "VL", name: "VL Mathematics for AI II", ects: 6, available: "SS", recommendedSemester: 2 },
-			{ type: "UE", name: "UE Mathematics for AI III", ects: 3, available: "WS", recommendedSemester: 3 },
-			{ type: "VL", name: "VL Mathematics for AI III", ects: 6, available: "WS", recommendedSemester: 3 },
-			{ type: "UE", name: "UE Numerical Optimization", ects: 1.5, available: "SS", recommendedSemester: 4 },
-			{ type: "VL", name: "VL Numerical Optimization", ects: 3, available: "SS", recommendedSemester: 4 },
-		],
-	},
-	{
-		name: "Bachelor Thesis",
-		courses: [{ type: "SE", name: "SE Bachelor Thesis", ects: 9, recommendedSemester: 6 }],
-	},
-];
-
-export const rawCourses: Course[] = courseGroups.reduce(
-	(acc, group) => acc.concat(group.courses.map((c) => ({ ...c, group: group.name, id: c.name }))),
-	[] as Course[]
-);
+export const generateRawCourses = (courseGroups: CourseGroup<string>[]) =>
+    courseGroups.reduce(
+        (acc, group) => acc.concat(
+            group.courses.map((course) => ({
+                ...course,
+                name: `${course.type} ${course.name}`,
+                group: group.name,
+                id: `${course.type} ${course.name}`,
+            }))
+        ),
+        [] as Course<string>[]
+    )

--- a/src/data/cs/courses.ts
+++ b/src/data/cs/courses.ts
@@ -1,0 +1,144 @@
+import {CourseGroup} from "@/types/courses";
+import {generateRawCourses} from "@/data/courses.ts";
+
+export type CourseName =
+    "Propaedeutic" |
+    "Discrete Structures" |
+    "Logic" |
+    "Algebra for Computer Science" |
+    "Analysis for Computer Science" |
+    "Computability and Complexity" |
+    "Formal Models" |
+    "Statistics" |
+    "Digital Circuits" |
+    "Electronics" |
+    "Computer Architecture" |
+    "Digital Signal Processing" |
+    "Software Development 1" |
+    "Software Development 2" |
+    "Algorithms and Data Structures 1" |
+    "Algorithms and Data Structures 2" |
+    "Systems Programming" |
+    "Practical Training in Software Development 2" |
+    "Software Engineering" |
+    "Operating Systems" |
+    "Multimedia Systems" |
+    "Computer Networks" |
+    "Compiler Construction" |
+    "Embedded and Pervasive Systems" |
+    "Databases and Information Systems 1" |
+    "Databases and Information Systems 2" |
+    "Computer Graphics" |
+    "Artificial Intelligence" |
+    "Introduction to Machine Learning" |
+    "Ethics and Gender Studies" |
+    "Law for Computer Science" |
+    "Techniques of Presentation and Team Work" |
+    "Project Management" |
+    "Economy for Computer Science"
+
+export const courseGroups: CourseGroup<CourseName>[] = [
+    {
+        name: "Propaedeutic",
+        courses: [
+            { type: "KV", name: "Propaedeutic", ects: 1.5, available: "WS", recommendedSemester: 1 },
+        ],
+    },
+    {
+        name: "Theory",
+        courses: [
+            { type: "VL", name: "Discrete Structures", ects: 3, available: "WS", recommendedSemester: 1 },
+            { type: "UE", name: "Discrete Structures", ects: 1.5, available: "WS", recommendedSemester: 1 },
+            { type: "VL", name: "Logic", ects: 3, available: "WS", recommendedSemester: 1 },
+            { type: "UE", name: "Logic", ects: 1.5, available: "WS", recommendedSemester: 1 },
+            { type: "VL", name: "Algebra for Computer Science", ects: 3, available: "SS", recommendedSemester: 2 },
+            { type: "UE", name: "Algebra for Computer Science", ects: 3, available: "SS", recommendedSemester: 2 },
+            { type: "VL", name: "Analysis for Computer Science", ects: 3, available: "WS", recommendedSemester: 3 },
+            { type: "UE", name: "Analysis for Computer Science", ects: 3, available: "WS", recommendedSemester: 3 },
+            { type: "VL", name: "Computability and Complexity", ects: 3, available: "WS", recommendedSemester: 3 },
+            { type: "UE", name: "Computability and Complexity", ects: 1.5, available: "WS", recommendedSemester: 3 },
+            { type: "VL", name: "Formal Models", ects: 3, available: "SS", recommendedSemester: 4 },
+            { type: "UE", name: "Formal Models", ects: 1.5, available: "SS", recommendedSemester: 4 },
+            { type: "VL", name: "Statistics", ects: 3, available: "SS", recommendedSemester: 4 },
+            { type: "UE", name: "Statistics", ects: 3, available: "SS", recommendedSemester: 4 },
+        ],
+    },
+    {
+        name: "Hardware",
+        courses: [
+            { type: "VL", name: "Digital Circuits", ects: 3, available: "WS", recommendedSemester: 1 },
+            { type: "UE", name: "Digital Circuits", ects: 1.5, available: "WS", recommendedSemester: 1 },
+            { type: "VL", name: "Electronics", ects: 3, available: "SS", recommendedSemester: 2 },
+            { type: "UE", name: "Electronics", ects: 1.5, available: "SS", recommendedSemester: 2 },
+            { type: "VL", name: "Computer Architecture", ects: 4.5, available: "SS", recommendedSemester: 4 },
+            { type: "UE", name: "Computer Architecture", ects: 1.5, available: "SS", recommendedSemester: 4 },
+            { type: "VL", name: "Digital Signal Processing", ects: 3, available: "SS", recommendedSemester: 6 },
+            { type: "UE", name: "Digital Signal Processing", ects: 1.5, available: "SS", recommendedSemester: 6 },
+        ],
+    },
+    {
+        name: "Software",
+        courses: [
+            { type: "VL", name: "Software Development 1", ects: 3, recommendedSemester: 1 },
+            { type: "UE", name: "Software Development 1", ects: 3, recommendedSemester: 1 },
+            { type: "VL", name: "Software Development 2", ects: 3, available: "SS", recommendedSemester: 2 },
+            { type: "UE", name: "Software Development 2", ects: 3, available: "SS", recommendedSemester: 2 },
+            { type: "VL", name: "Algorithms and Data Structures 1", ects: 3, available: "SS", recommendedSemester: 2 },
+            { type: "UE", name: "Algorithms and Data Structures 1", ects: 1.5, available: "SS", recommendedSemester: 2 },
+            { type: "VL", name: "Algorithms and Data Structures 2", ects: 3, available: "WS", recommendedSemester: 3 },
+            { type: "UE", name: "Algorithms and Data Structures 2", ects: 1.5, available: "WS", recommendedSemester: 3 },
+            { type: "VL", name: "Systems Programming", ects: 1.5, available: "WS", recommendedSemester: 3 },
+            { type: "UE", name: "Systems Programming", ects: 1.5, available: "WS", recommendedSemester: 3 },
+            { type: "PR", name: "Practical Training in Software Development 2", ects: 3, available: "SS", recommendedSemester: 4 },
+            { type: "VL", name: "Software Engineering", ects: 3, available: "WS", recommendedSemester: 5 },
+            { type: "UE", name: "Software Engineering", ects: 1.5, available: "WS", recommendedSemester: 5 },
+        ],
+    },
+    {
+        name: "Systems",
+        courses: [
+            { type: "VL", name: "Operating Systems", ects: 3, available: "SS", recommendedSemester: 2 },
+            { type: "UE", name: "Operating Systems", ects: 1.5, available: "SS", recommendedSemester: 2 },
+            { type: "VL", name: "Multimedia Systems", ects: 3, available: "SS", recommendedSemester: 2 },
+            { type: "UE", name: "Multimedia Systems", ects: 1.5, available: "SS", recommendedSemester: 2 },
+            { type: "VL", name: "Computer Networks", ects: 3, available: "WS", recommendedSemester: 3 },
+            { type: "UE", name: "Computer Networks", ects: 1.5, available: "WS", recommendedSemester: 3 },
+            { type: "VL", name: "Compiler Construction", ects: 3, available: "WS", recommendedSemester: 5 },
+            { type: "UE", name: "Compiler Construction", ects: 3, available: "WS", recommendedSemester: 5 },
+            { type: "VL", name: "Embedded & Pervasive Systems", ects: 3, available: "SS", recommendedSemester: 6 },
+            { type: "UE", name: "Embedded & Pervasive Systems", ects: 1.5, available: "SS", recommendedSemester: 6 },
+        ],
+    },
+    {
+        name: "Applications",
+        courses: [
+            { type: "VL", name: "Databases and Information Systems 1", ects: 3, available: "WS", recommendedSemester: 1 },
+            { type: "UE", name: "Databases and Information Systems 1", ects: 3, available: "WS", recommendedSemester: 1 },
+            { type: "VL", name: "Databases and Information Systems 2", ects: 3, available: "WS", recommendedSemester: 3 },
+            { type: "UE", name: "Databases and Information Systems 2", ects: 1.5, available: "WS", recommendedSemester: 3 },
+            { type: "VL", name: "Computer Graphics", ects: 3, available: "SS", recommendedSemester: 4 },
+            { type: "UE", name: "Computer Graphics", ects: 1.5, available: "SS", recommendedSemester: 4 },
+            { type: "VL", name: "Artificial Intelligence", ects: 3, available: "WS", recommendedSemester: 5 },
+            { type: "UE", name: "Artificial Intelligence", ects: 1.5, available: "WS", recommendedSemester: 5 },
+            { type: "VL", name: "Introduction to Machine Learning", ects: 3, available: "WS", recommendedSemester: 5 },
+        ],
+    },
+    {
+        name: "Complementary Skills",
+        courses: [
+            { type: "KV", name: "Ethics and Gender Studies", ects: 3, available: "WS", recommendedSemester: 1 },
+            { type: "VL", name: "Law for Computer Science", ects: 3, available: "WS", recommendedSemester: 3 },
+            { type: "KV", name: "Techniques of Presentation and Team Work", ects: 3, available: "SS", recommendedSemester: 4 },
+            { type: "KV", name: "Project Management", ects: 3, available: "WS", recommendedSemester: 5 },
+            { type: "VL", name: "Economy for Computer Science", ects: 3, available: "SS", recommendedSemester: 6 },
+        ],
+    },
+    {
+        name: "Bachelor Thesis",
+        courses: [
+            { type: "PR", name: "Project Practical", ects: 7.5, recommendedSemester: 6 },
+        ],
+    },
+]
+
+export const rawCourses = generateRawCourses(courseGroups)

--- a/src/data/cs/dependencies.ts
+++ b/src/data/cs/dependencies.ts
@@ -1,0 +1,136 @@
+import {Dependencies} from "@/types/dependencies";
+import {CourseName} from "@/data/cs/courses";
+
+export const dependencies: Dependencies<CourseName> = [
+    {
+        name: "Discrete Structures",
+        dependencies: [
+            { name: "Logic", type: "hard" },
+        ],
+    },
+    {
+        name: "Digital Circuits",
+        dependencies: [
+            { name: "Logic", type: "hard" },
+        ],
+    },
+    {
+        name: "Algebra for Computer Science",
+        dependencies: [
+            { name: "Discrete Structures", type: "hard" },
+        ],
+    },
+    {
+        name: "Algorithms and Data Structures 1",
+        dependencies: [
+            { name: "Software Development 1", type: "hard" },
+        ],
+    },
+    {
+        name: "Software Development 2",
+        dependencies: [
+            { name: "Software Development 1", type: "hard" },
+        ],
+    },
+    {
+        name: "Electronics",
+        dependencies: [
+            { name: "Digital Circuits", type: "soft" },
+        ],
+    },
+    {
+        name: "Computability and Complexity",
+        dependencies: [
+            { name: "Discrete Structures", type: "hard" }
+        ],
+    },
+    {
+        name: "Algorithms and Data Structures 2",
+        dependencies: [
+            { name: "Algorithms and Data Structures 1", type: "hard" },
+        ],
+    },
+    {
+        name: "Systems Programming",
+        dependencies: [
+            { name: "Software Development 1", type: "hard" },
+            { name: "Operating Systems", type: "hard" },
+        ],
+    },
+    {
+        name: "Computer Networks",
+        dependencies: [
+            { name: "Operating Systems", type: "hard" },
+        ],
+    },
+    {
+        name: "Databases and Information Systems 2",
+        dependencies: [
+            { name: "Databases and Information Systems 1", type: "hard" },
+        ],
+    },
+    {
+        name: "Formal Models",
+        dependencies: [
+            { name: "Logic", type: "hard" },
+            { name: "Discrete Structures", type: "hard" },
+        ],
+    },
+    {
+        name: "Computer Graphics",
+        dependencies: [
+            { name: "Algebra for Computer Science", type: "hard" },
+            { name: "Algorithms and Data Structures 2", type: "hard"},
+        ],
+    },
+    {
+        name: "Practical Training in Software Development 2",
+        dependencies: [
+            { name: "Software Development 2", type: "hard" },
+        ],
+    },
+    {
+        name: "Computer Architecture",
+        dependencies: [
+            { name: "Digital Circuits", type: "hard" },
+        ],
+    },
+    {
+        name: "Artificial Intelligence",
+        dependencies: [
+            { name: "Discrete Structures", type: "hard" },
+            { name: "Computability and Complexity", type: "hard" },
+            { name: "Algorithms and Data Structures 2", type: "hard" },
+        ],
+    },
+    {
+        name: "Compiler Construction",
+        dependencies: [
+            { name: "Computability and Complexity", type: "hard" },
+            { name: "Software Development 2", type: "hard" },
+        ],
+    },
+    {
+        name: "Software Engineering",
+        dependencies: [
+            { name: "Software Development 2", type: "hard" },
+        ],
+    },
+    {
+        name: "Digital Signal Processing",
+        dependencies: [
+            { name: "Algebra for Computer Science", type: "hard" },
+            { name: "Analysis for Computer Science", type: "hard" },
+            { name: "Digital Circuits", type: "soft" },
+            { name: "Electronics", type: "hard" },
+        ],
+    },
+    {
+        name: "Embedded and Pervasive Systems",
+        dependencies: [
+            { name: "Computer Networks", type: "hard" },
+            { name: "Statistics", type: "soft" },
+            { name: "Computer Architecture", type: "soft" },
+        ],
+    },
+]

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -23,18 +23,25 @@ export const getGroupColor = (group: string) => {
 	switch (group) {
 		case "Bachelor Thesis":
 		case "AI Basics and Practical Training":
+		case "Propaedeutic":
 			return colorPalate[0];
 		case "AI and Society":
+		case "Theory":
 			return colorPalate[1];
 		case "Computer Science":
+		case "Hardware":
 			return colorPalate[2];
 		case "Data Science":
+		case "Software":
 			return colorPalate[3];
 		case "Knowledge Representation and Reasoning":
+		case "Systems":
 			return colorPalate[4];
 		case "Machine Learning and Perception":
+		case "Applications":
 			return colorPalate[5];
 		case "Mathematics":
+		case "Complementary Skills":
 			return colorPalate[6];
 	}
 };

--- a/src/screens/settings-screen.tsx
+++ b/src/screens/settings-screen.tsx
@@ -8,20 +8,23 @@ import { rawCourses } from "@/data/courses";
 import { cn } from "@/lib/utils";
 import { gradesAtom } from "@/store/grades";
 import { planningAtom } from "@/store/planning";
-import { exportAtom, startingSemesterAtom } from "@/store/settings";
+import {exportAtom, programmAtom, startingSemesterAtom} from "@/store/settings";
 import { SemesterType } from "@/types/courses";
 import { useAtom } from "jotai";
-import { FileUp, Lock } from "lucide-react";
+import { FileUp, Lock, OctagonAlert } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
+import {ProgrammToggle} from "@/components/programm-toggle.tsx";
 
 export default function SettingsScreen() {
 	const [exportData, importData] = useAtom(exportAtom);
 
+	const [wantsChangeProgramm, setWantsChangeProgram] = useState(false);
 	const [hasBackuped, setHasBackuped] = useState(false);
 
 	const [, setPlanning] = useAtom(planningAtom);
 	const [, setGrading] = useAtom(gradesAtom);
+	const [programm, ] = useAtom(programmAtom);
 
 	const exportFile = () => {
 		const data = JSON.stringify(exportData);
@@ -127,6 +130,27 @@ export default function SettingsScreen() {
 					<Label htmlFor="mode-toggle">Dark Mode</Label>
 					<ModeToggle />
 				</CardContent>
+			</Card>
+			<Card className={"relative"}>
+				<CardHeader className={cn(!wantsChangeProgramm && "blur-sm")}>
+					<CardTitle>Change Programm</CardTitle>
+				</CardHeader>
+				<CardContent className={cn("flex flex-col gap-4", !wantsChangeProgramm && "blur-sm")}>
+					<Label htmlFor="programm-toggle" className="sr-only">Bachelor's Programm</Label>
+					<ProgrammToggle />
+				</CardContent>
+				{!wantsChangeProgramm && (
+					<div className="bg-gray-800/40 w-full h-full absolute top-0 rounded-md flex flex-col items-center justify-center text-white gap-2">
+						<OctagonAlert size={50} />
+						<h2 className="text-center font-bold m-2">
+							Changing your Bachelor's programm will reset your data!
+							Back up (Export) your Data before abandoning your current programm!
+						</h2>
+						<Button onClick={() => setWantsChangeProgram(true)} variant={"destructive"}>
+							I have enough of { programm }!
+						</Button>
+					</div>
+				)}
 			</Card>
 			<Card className={"relative"}>
 				<CardHeader className={cn(!hasBackuped && "blur-sm")}>

--- a/src/screens/settings-screen.tsx
+++ b/src/screens/settings-screen.tsx
@@ -4,11 +4,10 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
-import { rawCourses } from "@/data/courses";
 import { cn } from "@/lib/utils";
 import { gradesAtom } from "@/store/grades";
 import { planningAtom } from "@/store/planning";
-import {exportAtom, programmAtom, startingSemesterAtom} from "@/store/settings";
+import {exportAtom, programmAtom, rawCoursesAtom, startingSemesterAtom} from "@/store/settings";
 import { SemesterType } from "@/types/courses";
 import { useAtom } from "jotai";
 import { FileUp, Lock, OctagonAlert } from "lucide-react";
@@ -17,6 +16,8 @@ import { toast } from "sonner";
 import {ProgrammToggle} from "@/components/programm-toggle.tsx";
 
 export default function SettingsScreen() {
+	const [rawCourses] = useAtom(rawCoursesAtom);
+
 	const [exportData, importData] = useAtom(exportAtom);
 
 	const [wantsChangeProgramm, setWantsChangeProgram] = useState(false);
@@ -60,6 +61,7 @@ export default function SettingsScreen() {
 
 	const resetToRecommended = () => {
 		setPlanning(rawCourses.map((c) => ({ name: c.name, plannedSemester: c.recommendedSemester! })));
+		console.log(rawCourses.map((c) => ({ name: c.name, plannedSemester: c.recommendedSemester! })))
 		setStartingSemester({ year: new Date().getFullYear(), type: "WS" });
 		toast.success("Successfully reset to recommended study plan");
 	};

--- a/src/screens/settings-screen.tsx
+++ b/src/screens/settings-screen.tsx
@@ -7,25 +7,25 @@ import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { cn } from "@/lib/utils";
 import { gradesAtom } from "@/store/grades";
 import { planningAtom } from "@/store/planning";
-import {exportAtom, programmAtom, rawCoursesAtom, startingSemesterAtom} from "@/store/settings";
+import {exportAtom, programAtom, rawCoursesAtom, startingSemesterAtom} from "@/store/settings";
 import { SemesterType } from "@/types/courses";
 import { useAtom } from "jotai";
 import { FileUp, Lock, OctagonAlert } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
-import {ProgrammToggle} from "@/components/programm-toggle.tsx";
+import {ProgramToggle} from "@/components/program-toggle.tsx";
 
 export default function SettingsScreen() {
 	const [rawCourses] = useAtom(rawCoursesAtom);
 
 	const [exportData, importData] = useAtom(exportAtom);
 
-	const [wantsChangeProgramm, setWantsChangeProgram] = useState(false);
+	const [wantsChangeProgram, setWantsChangeProgram] = useState(false);
 	const [hasBackuped, setHasBackuped] = useState(false);
 
 	const [, setPlanning] = useAtom(planningAtom);
 	const [, setGrading] = useAtom(gradesAtom);
-	const [programm, ] = useAtom(programmAtom);
+	const [program, ] = useAtom(programAtom);
 
 	const exportFile = () => {
 		const data = JSON.stringify(exportData);
@@ -134,22 +134,22 @@ export default function SettingsScreen() {
 				</CardContent>
 			</Card>
 			<Card className={"relative"}>
-				<CardHeader className={cn(!wantsChangeProgramm && "blur-sm")}>
-					<CardTitle>Change Programm</CardTitle>
+				<CardHeader className={cn(!wantsChangeProgram && "blur-sm")}>
+					<CardTitle>Change Program</CardTitle>
 				</CardHeader>
-				<CardContent className={cn("flex flex-col gap-4", !wantsChangeProgramm && "blur-sm")}>
-					<Label htmlFor="programm-toggle" className="sr-only">Bachelor's Programm</Label>
-					<ProgrammToggle />
+				<CardContent className={cn("flex flex-col gap-4", !wantsChangeProgram && "blur-sm")}>
+					<Label htmlFor="program-toggle" className="sr-only">Bachelor's Program</Label>
+					<ProgramToggle />
 				</CardContent>
-				{!wantsChangeProgramm && (
+				{!wantsChangeProgram && (
 					<div className="bg-gray-800/40 w-full h-full absolute top-0 rounded-md flex flex-col items-center justify-center text-white gap-2">
 						<OctagonAlert size={50} />
 						<h2 className="text-center font-bold m-2">
-							Changing your Bachelor's programm will reset your data!
-							Back up (Export) your Data before abandoning your current programm!
+							Changing your Bachelor's Program will reset your data!
+							Back up (Export) your Data before abandoning your current program!
 						</h2>
 						<Button onClick={() => setWantsChangeProgram(true)} variant={"destructive"}>
-							I have enough of { programm }!
+							I have enough of { program }!
 						</Button>
 					</div>
 				)}

--- a/src/store/settings.ts
+++ b/src/store/settings.ts
@@ -33,9 +33,17 @@ export const exportAtom = atom(
 	}
 );
 
-export const settingsAtom = atomWithStorage("settings", {
+export type Programm = "AI" | "CS";
+export type Settings = {
+	startingSemester: Semester,
+	ignoreGraded: boolean,
+	programm: Programm,
+}
+
+export const settingsAtom = atomWithStorage<Settings>("settings", {
 	startingSemester: getCurrentSemester(),
 	ignoreGraded: false,
+	programm: "AI"
 });
 
 export const startingSemesterAtom = atom(
@@ -52,3 +60,10 @@ export const ignoreGradedAtom = atom(
 		set(settingsAtom, { ...get(settingsAtom), ignoreGraded: value });
 	}
 );
+
+export const programmAtom = atom(
+	(get) => get(settingsAtom).programm,
+	(get, set, value: Programm) => {
+		set(settingsAtom, { ...get(settingsAtom), programm: value });
+	}
+)

--- a/src/store/settings.ts
+++ b/src/store/settings.ts
@@ -69,7 +69,7 @@ export const ignoreGradedAtom = atom(
 );
 
 export const programmAtom = atom(
-	(get) => get(settingsAtom).programm,
+	(get) => get(settingsAtom).programm ?? "AI",
 	(get, set, value: Programm) => {
 		set(settingsAtom, { ...get(settingsAtom), programm: value });
 	}

--- a/src/store/settings.ts
+++ b/src/store/settings.ts
@@ -40,17 +40,17 @@ export const exportAtom = atom(
 	}
 );
 
-export type Programm = "AI" | "CS";
+export type Program = "AI" | "CS";
 export type Settings = {
 	startingSemester: Semester,
 	ignoreGraded: boolean,
-	programm: Programm,
+	program: Program,
 }
 
 export const settingsAtom = atomWithStorage<Settings>("settings", {
 	startingSemester: getCurrentSemester(),
 	ignoreGraded: false,
-	programm: "AI"
+	program: "AI"
 });
 
 export const startingSemesterAtom = atom(
@@ -68,21 +68,21 @@ export const ignoreGradedAtom = atom(
 	}
 );
 
-export const programmAtom = atom(
-	(get) => get(settingsAtom).programm ?? "AI",
-	(get, set, value: Programm) => {
-		set(settingsAtom, { ...get(settingsAtom), programm: value });
+export const programAtom = atom(
+	(get) => get(settingsAtom).program ?? "AI",
+	(get, set, value: Program) => {
+		set(settingsAtom, { ...get(settingsAtom), program: value });
 	}
 )
 
 export const courseGroupsAtom = atom<CourseGroup<string>[]>(
-	(get) => get(programmAtom) == "AI" ? aiCourseGroups : csCourseGroups,
+	(get) => get(programAtom) == "AI" ? aiCourseGroups : csCourseGroups,
 )
 
 export const rawCoursesAtom = atom<Course<string>[]>(
-	(get) => get(programmAtom) == "AI" ? aiRawCourses : csRawCourses,
+	(get) => get(programAtom) == "AI" ? aiRawCourses : csRawCourses,
 )
 
 export const dependenciesAtom = atom<Dependencies<string>>(
-	(get) => get(programmAtom) == "AI" ? aiDependencies : csDependencies,
+	(get) => get(programAtom) == "AI" ? aiDependencies : csDependencies,
 )

--- a/src/store/settings.ts
+++ b/src/store/settings.ts
@@ -1,10 +1,17 @@
 import { getCurrentSemester } from "@/lib/semester";
-import { Semester } from "@/types/courses";
+import {Course, CourseGroup, Semester} from "@/types/courses";
 import { atom } from "jotai";
 import { atomWithStorage } from "jotai/utils";
 import { toast } from "sonner";
 import { gradesAtom } from "./grades";
 import { planningAtom } from "./planning";
+
+import { courseGroups as aiCourseGroups, rawCourses as aiRawCourses } from "@/data/ai/courses";
+import { dependencies as aiDependencies} from "@/data/ai/dependencies.ts";
+
+import { courseGroups as csCourseGroups, rawCourses as csRawCourses } from "@/data/cs/courses.ts";
+import { dependencies as csDependencies } from "@/data/cs/dependencies.ts";
+import {Dependencies} from "@/types/dependencies";
 
 export const exportAtom = atom(
 	(get) => {
@@ -66,4 +73,16 @@ export const programmAtom = atom(
 	(get, set, value: Programm) => {
 		set(settingsAtom, { ...get(settingsAtom), programm: value });
 	}
+)
+
+export const courseGroupsAtom = atom<CourseGroup<string>[]>(
+	(get) => get(programmAtom) == "AI" ? aiCourseGroups : csCourseGroups,
+)
+
+export const rawCoursesAtom = atom<Course<string>[]>(
+	(get) => get(programmAtom) == "AI" ? aiRawCourses : csRawCourses,
+)
+
+export const dependenciesAtom = atom<Dependencies<string>>(
+	(get) => get(programmAtom) == "AI" ? aiDependencies : csDependencies,
 )

--- a/src/store/tableOptions.ts
+++ b/src/store/tableOptions.ts
@@ -2,7 +2,7 @@ import { Course } from "@/types/courses";
 import { atom } from "jotai";
 
 export const searchQueryAtom = atom("");
-export const sortFieldAtom = atom<keyof Course | "status" | null>(null);
+export const sortFieldAtom = atom<keyof Course<string> | "status" | null>(null);
 export const sortOrderAtom = atom<"asc" | "desc">("asc");
 export const selectedTypesAtom = atom<string[]>([]);
 export const selectedGroupsAtom = atom<string[]>([]);

--- a/src/types/courses.d.ts
+++ b/src/types/courses.d.ts
@@ -3,8 +3,8 @@ export interface Semester {
 	year: number;
 	type: SemesterType;
 }
-export interface Course {
-	name: string;
+export interface Course<Name extends string> {
+	name: Name;
 	ects: number;
 	id: string;
 	available?: SemesterType;
@@ -16,9 +16,9 @@ export interface Course {
 	notUsedForDistinction?: boolean;
 }
 
-export interface CourseGroup {
+export interface CourseGroup<Name extends string> {
 	name: string;
-	courses: Omit<Course, "group", "id">[];
+	courses: Omit<Course<Name>, "group", "id", "fullName">[];
 }
 
 export interface CourseGrading {

--- a/src/types/dependencies.d.ts
+++ b/src/types/dependencies.d.ts
@@ -1,0 +1,13 @@
+export type DependencyType = "hard" | "soft" | "recommended";
+
+export interface Dependency<CourseName extends string> {
+    name: CourseName;
+    type: DependencyType;
+}
+
+export interface CourseDependencies<CourseName extends string> {
+    name: CourseName
+    dependencies: Dependency<CourseName>[]
+}
+
+export type Dependencies<CourseName extends string> = CourseDependencies<CourseName>[]


### PR DESCRIPTION
This pull request
_in short_: adds support for CS

_in long_:
- adds a new card to the settings, where you can change your bachelor's programm to "CS"
  - by default AI is assumed 
  - the data of previous users will be preserved and set as "AI" data per default
  - a user is warned, that chaning the programm will reset all data
- adds new data file for cs study data
  - moves the course name from dependencies to courses, to have autocompletion
  - now automatically compiles the course name from `course.type + course.name`
- adds three new atoms for getting the right data (and uses them where needed)